### PR TITLE
1.12.1 fix(dupe-foe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.12.1
+
+- **Updated**
+  - Fixed bug causing `Duplicate Foe` to fail on certain strikes (🐛 @Maple)
+  - Added a check for the level of the target for `Duplicate Foe`
+
 ## 1.12.0
 
 - **New**
@@ -55,7 +61,7 @@
 ## 1.8.3
 
 - **Updates**
-  - Fixed bug causing all summons to fail (🐛@Le Chat Lunatique)
+  - Fixed bug causing all summons to fail (🐛 @Le Chat Lunatique)
 
 ## 1.8.2
 

--- a/languages/en.json
+++ b/languages/en.json
@@ -44,6 +44,9 @@
     "notification": {
       "summoner": {
         "too-many-eidolons": "You own too many eidolons."
+      },
+      "duplicate-foe": {
+        "too-high": "The foe is too high level for this rank of Duplicate Foe"
       }
     },
     "dialog": {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -35,10 +35,7 @@ Hooks.once("ready", async function () {
 
     if (chatMessage?.flags?.pf2e?.appliedDamage) return;
 
-    // TODO handle Incarnate spells at a later date
-    //if (!chatMessage?.flags?.pf2e?.origin?.rollOptions?.includes("summon")) return;
     let summonLevel = 20;
-    //attributes.classDC.value
 
     const summonerActor = ChatMessage.getSpeakerActor(chatMessage.speaker);
 

--- a/scripts/specificSummons.js
+++ b/scripts/specificSummons.js
@@ -108,7 +108,13 @@ export async function getSpecificSummonDetails(uuid, data = {
 
         case SOURCES.MISC.DUPLICATE_FOE:
             const token = await fromUuid(data.targetTokenUUID);
+            const maxLevel = (data.rank - 7) * 2 + 15
             if (token) {
+                if (token?.actor?.level <= maxLevel) {
+                    ui.notifications.error(game.i18n.localize("pf2e-summons-assistant.notification.duplicate-foe.too-high"))
+                    return null;
+                }
+
                 const info = await getFoeInfo(token, data.rank)
                 const isFail = await foundry.applications.api.DialogV2.confirm({
                     content: game.i18n.localize("pf2e-summons-assistant.dialog.duplicate-foe"),

--- a/scripts/specificSummons.js
+++ b/scripts/specificSummons.js
@@ -110,7 +110,7 @@ export async function getSpecificSummonDetails(uuid, data = {
             const token = await fromUuid(data.targetTokenUUID);
             const maxLevel = (data.rank - 7) * 2 + 15
             if (token) {
-                if (token?.actor?.level <= maxLevel) {
+                if (token?.actor?.level > maxLevel) {
                     ui.notifications.error(game.i18n.localize("pf2e-summons-assistant.notification.duplicate-foe.too-high"))
                     return null;
                 }


### PR DESCRIPTION

- **Updated**
  - Fixed bug causing `Duplicate Foe` to fail on certain strikes (🐛 @Maple)
  - Added a check for the level of the target for `Duplicate Foe`