### PR TITLE
Use elite/weak level adjustment for determining allowed summons

### DIFF
--- a/scripts/summon.js
+++ b/scripts/summon.js
@@ -57,9 +57,29 @@ export async function summon(
         //packs: ['pf2e.pathfinder-monster-core'],
         noSummon: true,
         filter: (candidateActor) => {
+          let levelAdjustment;
+          switch (candidateActor.system?.attributes?.adjustment) {
+            case 'elite': 
+              if (candidateActor.system.details.level.value <= 0) {
+                levelAdjustment = 2
+              } else {
+                levelAdjustment = 1;
+              }
+              break;
+            case 'weak':
+              if (candidateActor.system.details.level.value === 1) {
+                levelAdjustment = -2
+              } else {
+                levelAdjustment = -1;
+              }
+              break;
+            default:
+              levelAdjustment = 0;
+              break;
+          }
           const isCommonAndValidLevel =
             candidateActor.system?.traits?.rarity === "common" &&
-            candidateActor.system.details.level.value <= summonLevel;
+            candidateActor.system.details.level.value + levelAdjustment <= summonLevel;
 
           const hasValidTraits =
             requiredTraits.length === 0 ||
@@ -131,6 +151,7 @@ export async function summon(
               );
             },
             indexedFields: [
+              "system.attributes.adjustment",
               "system.details.level.value",
               "system.traits.value",
               "system.traits.rarity",


### PR DESCRIPTION
The level adjustments from [weak/elite variants](https://2e.aonprd.com/Rules.aspx?ID=3262) (usually -1/+1) were not considered when selecting a summon.

An example of that occuring is Skeletal Crocodile (Compendium.pf2e.outlaws-of-alkenstar-bestiary.Actor.3BFECcR5ggVH69Gu) which is an elite with base level 7 and adjusted level 8. It can be currently summoned by 6th rank summon undead which should not be allowed.
