### PR TITLE
Fix Mechanic's Mine automation for the SF2e system

### DIFF
--- a/packs/pf2e-summons-assistant-actors/_source/Mine_sAVuxP25VE126TdZ.json
+++ b/packs/pf2e-summons-assistant-actors/_source/Mine_sAVuxP25VE126TdZ.json
@@ -352,7 +352,7 @@
             ],
             "mode": "override",
             "property": "damage-type",
-            "value": "{item|flags.pf2e.rulesSelections.mineDamageType}",
+            "value": "{item|flags.system.rulesSelections.mineDamageType}",
             "predicate": [
               {
                 "not": "critical-explosion-persistent-damage"
@@ -390,7 +390,7 @@
                 ]
               },
               {
-                "text": "A creature that critically fails its saving throw against one of your mines is additionally dealt persistent damage equal to your Intelligence modifier @Damage[(@actor.system.abilities.int.mod)[persistent, {item|flags.pf2e.rulesSelections.mineDamageType}]|options:critical-explosion-persistent-damage].",
+                "text": "A creature that critically fails its saving throw against one of your mines is additionally dealt persistent damage equal to your Intelligence modifier @Damage[(@actor.system.abilities.int.mod)[persistent, {item|flags.system.rulesSelections.mineDamageType}]|options:critical-explosion-persistent-damage].",
                 "predicate": [
                   {
                     "nor": [

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -20,7 +20,7 @@ export function addTraits(type) {
 }
 
 export function messageItemHasRollOption(msg, roll_option) {
-  return msg?.flags?.pf2e?.origin?.rollOptions?.includes(roll_option);
+  return msg?.flags?.[game.system.id]?.origin?.rollOptions?.includes(roll_option);
 }
 
 export function hasNoTargets() {
@@ -174,6 +174,8 @@ export function convertItemUUIDBasedOnSystem(uuid) {
     finalUUID = finalUUID
       .replace(".sf2e.", ".pf2e.")
       .replace(".pf2e-anachronism.", ".pf2e.")
+      .replace(".starfinder-field-test-for-pf2e.actions.", ".starfinder-field-test-for-pf2e.sf2e-actions.")
+      .replace(".starfinder-field-test-for-pf2e.feats.", ".starfinder-field-test-for-pf2e.sf2e-feats.")
       .replace(".actions.", ".actionspf2e.")
       .replace(".class-features.", ".classfeatures.")
       .replace(".conditions.", ".conditionitems.")

--- a/scripts/specificClasses/mechanic.js
+++ b/scripts/specificClasses/mechanic.js
@@ -1,5 +1,5 @@
 import { FEATS } from "../const.js";
-import { messageItemHasRollOption } from "../helpers.js";
+import { messageItemHasRollOption, convertItemUUIDBasedOnSystem } from "../helpers.js";
 
 export function isMechanic(msg) {
     return messageItemHasRollOption(msg, "origin:item:trait:mechanic");
@@ -9,6 +9,6 @@ export function setMechanicRelevantInfo(mechanicActor, spellRelevantInfo) {
     spellRelevantInfo.classDC = mechanicActor.system.proficiencies.classDCs.mechanic?.value;
     spellRelevantInfo.int = mechanicActor.system.abilities.int.mod;
     spellRelevantInfo.hasCriticalExplosion = mechanicActor.itemTypes.feat?.some(
-        p => p.sourceId === FEATS.MECHANIC.CRITICAL_EXPLOSION
+        p => p.sourceId === convertItemUUIDBasedOnSystem(FEATS.MECHANIC.CRITICAL_EXPLOSION)
     );
 }


### PR DESCRIPTION
I noticed that some of the automation for the mechanic's mine wasn't being applied as it didn't convert the SF2e playtest feats and actions UUIDs to their SF2e versions, and there were still some rule elements using "flags.pf2e" instead of "flags.system" in the Mine actor.