### PR TITLE
Scale the damage of Perfected Thrall and of the thralls spawned by Li…

### DIFF
--- a/scripts/specificSummons.js
+++ b/scripts/specificSummons.js
@@ -1281,6 +1281,7 @@ const handlers = {
           itemsToAdd: [
             EFFECTS.NECROMANCER.THRALL_EXPIRATION(data.duration, {
               uuid: SOURCES.NECROMANCER.CREATE_THRALL,
+              necromancerLevel: data.summonerLevel,
               castRank: data.rank,
               rollOptions: data.summonerRollOptions,
             }),
@@ -1298,6 +1299,7 @@ const handlers = {
           itemsToAdd: [
             EFFECTS.NECROMANCER.THRALL_EXPIRATION(data.duration, {
               uuid: SOURCES.NECROMANCER.PERFECTED_THRALL,
+              necromancerLevel: data.summonerLevel,
               castRank: data.rank,
               rollOptions: data.summonerRollOptions,
             }),


### PR DESCRIPTION
The number of d6's for the strike damage of the Perfected Thrall and of the thralls that spawn when the Living Graveyard should depend on the necromancer's level, like the other thralls.