### PR TITLE
Scale Skeletal Lancers on summoner level

### DIFF
--- a/scripts/specificSummons.js
+++ b/scripts/specificSummons.js
@@ -1343,6 +1343,7 @@ const handlers = {
             ]),
             EFFECTS.NECROMANCER.THRALL_EXPIRATION(data.duration, {
               uuid: SOURCES.NECROMANCER.SKELETAL_LANCERS,
+              necromancerLevel: data.summonerLevel,
               castRank: data.rank,
               rollOptions: data.summonerRollOptions,
             }),


### PR DESCRIPTION
The Skeletal Lancers base damage should also scale based on the Necromancer's level like all other thralls :)